### PR TITLE
dataframes.jl cleanup

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -8,7 +8,7 @@ function quandl(id::String; order="des", rows=100, period="daily", transformatio
         auth_token = open(readall, Pkg.dir("Quandl/src/token/auth_token.jl"))
     end
 
-    length(auth_token) > 50 || auth_token != "" ? query_args["auth_token"] = auth_token : nothing
+    length(auth_token) < 50 || auth_token != "" ? query_args["auth_token"] = auth_token : nothing
 
     # Get the response from Quandl's API, using Query arguments (see Response.jl README)
     response = get("http://www.quandl.com/api/v1/datasets/$id.csv", query = query_args) 

--- a/src/dataframe.jl
+++ b/src/dataframe.jl
@@ -1,5 +1,5 @@
-# function dataframe(rq::Response)
-function dataframe(response)
+function dataframe(response::Requests.Response)
+
 	buffer = PipeBuffer() # open a buffer in which to dump data
 	df     = DataFrame()  # init empty DataFrame
 


### PR DESCRIPTION
Cleanup of the dataframe() function. Now, we write the response.data directly to the buffer (we don't need to chomp, to split or to write line-by-line to the buffer, and we don't need the `data` variable). I also changed variable names to better readability.

I just don't understand two things:
- Why don't we make use of multiple dispatch to make sure that the argument passed to our function is of the type `Response`? This lead us to the second question...
- Why don't we use names like `DataFrame()` and `TimeArray()` to our functions? They are, after all, just new constructors, with a `Response` object as argument
