### PR TITLE
Allow start/end date(s) in query

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The `quandl` (or `quandlget`) function takes one positional argument (the Quandl
 - `rows`, which is the number of rows that the returned Dataset will have (default is `100`);
 - `frequency`, which is the frequency desired for the Dataset (default is `daily`);
 - `transformation`, which is the calculation Quandl do to to Dataset prior to download (default is `none`);
+- `start`, which is the starting date for the Dataset (default is `""`);
+- `end`, which is the ending date for the Dataset (default is `""`);
 - `auth_key`, which is user's API key (see the next section for further information);
 - `format`, which is the type returned by the function (default is `"TimeArray"`, but you can use `"DataFrame"` also).
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,11 +1,16 @@
-function quandlget(id::String; order="des", rows=100, frequency="daily", transformation="none", format="TimeArray", auth_token="")
+function quandlget(id::String; order="des", rows=100, frequency="daily", transformation="none", start="", end="", format="TimeArray", auth_token="")
     
     # Create a dictionary with the Query arguments that we pass to get() function
-    query_args = {"sort_order" => order, "rows" => rows, "collapse" => frequency, "transformation" => transformation}
+    query_args = {"sort_order" => order, "rows" => rows, "collapse" => frequency, "transformation" => transformation, "trim_start" => start, "trim_end" => end}
 
     # Open the auth_token file and add the token (if any) to the Query dictionary
     if auth_token == ""
         auth_token = open(readall, Pkg.dir("Quandl/src/token/auth_token.jl"))
+    end
+
+    # Do not use rows if start or end date range specified
+    if start != "" || end != ""
+        delete!(query_args, "rows")
     end
 
     length(auth_token) < 50 && auth_token != "" ? query_args["auth_token"] = auth_token : nothing


### PR DESCRIPTION
Hi folks,

updated to 'start' and 'end' for the date range parameters. (sorry, tried --amend but messed up for some reason)
