### PR TITLE
Replace readtable() with CSV.read()

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.5
 TimeSeries 0.9.0
 DataFrames
 Requests
+CSV

--- a/src/Quandl.jl
+++ b/src/Quandl.jl
@@ -4,7 +4,7 @@ using Base.Dates, TimeSeries, DataFrames
 
 module Quandl
 
-using Base.Dates, TimeSeries, DataFrames, Requests
+using Base.Dates, TimeSeries, DataFrames, Requests, CSV
 
 export quandlget,
        quandl,

--- a/src/dataframe.jl
+++ b/src/dataframe.jl
@@ -1,21 +1,6 @@
 function dataframe(resp::Requests.Response)
 
-    buffer = PipeBuffer() # open a buffer in which to dump data
-    df     = DataFrame()  # init empty DataFrame
-
-    try
-        # Write the data to the buffer
-        write(buffer, Requests.text(resp))
-
-        # Use DataFrame's readtable to read the data directly from buffer
-        df = readtable(buffer)
-        
-        # Convert dates to Dates object
-        df[:Date] = Date[Date(d) for d in df[:Date]]
-
-    finally
-        close(buffer)   
-    end
+    df = CSV.read(IOBuffer(Requests.text(resp)))
 
     # force oldest date to first row
 


### PR DESCRIPTION
DataFrames v0.11 will no longer provide `readtable()` ([PR#1220](https://github.com/JuliaData/DataFrames.jl/pull/1220/commits/5ce68c5e7d9da44f9417291de2c6b5fa4dd3c3f3) [PR#1223](https://github.com/JuliaData/DataFrames.jl/pull/1223)).  Replace with `CSV.read()`.